### PR TITLE
Basic support for macros

### DIFF
--- a/.github/workflows/build_and_run.yml
+++ b/.github/workflows/build_and_run.yml
@@ -1,0 +1,52 @@
+name: build and run tests
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build_ubuntu:
+
+    name: Test on Ubuntu
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - name: Update Rust
+      run: rustup update
+
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test
+    - name: Run tests (release)
+      run: cargo test --release
+
+  build_windows:
+
+    name: Test on Windows
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v1
+
+      - name: Update Rust
+        run: rustup update
+        shell: pwsh
+
+      - name: Build
+        run: cargo build --verbose
+        shell: pwsh
+      - name: Run tests
+        run: cargo test
+        shell: pwsh
+      - name: Run tests (release)
+        run: cargo test --release
+        shell: pwsh

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ quote = "1.0"
 [dependencies.syn]
 version = "1.0"
 default-features = false
-features = ["visit-mut", "printing", "full", "parsing", "proc-macro", "clone-impls"]
+features = ["visit", "visit-mut", "printing", "full", "parsing", "proc-macro", "clone-impls"]
 
 [dev-dependencies]
 num = "0.2.0"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 numeric_literals
 ================
 
+[![Build Status](https://github.com/Andlon/numeric_literals/workflows/build%20and%20run%20tests/badge.svg)](https://github.com/Andlon/numeric_literals/actions)
+
 **numeric_literals** is a Rust library that provides procedural attribute macros for replacing
 numeric literals with arbitrary expressions.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,8 +87,11 @@ use proc_macro::TokenStream;
 
 use syn::parse::Parser;
 use syn::punctuated::{Pair, Punctuated};
+use syn::visit::Visit;
 use syn::visit_mut::{visit_expr_mut, VisitMut};
-use syn::{parse_macro_input, Expr, ExprLit, Item, Lit, Macro, Token};
+use syn::{
+    parse_macro_input, Expr, ExprAssign, ExprLit, ExprPath, Item, Lit, LitBool, Macro, Token,
+};
 
 use quote::{quote, ToTokens};
 
@@ -96,17 +99,20 @@ use quote::{quote, ToTokens};
 /// with the replacement expression, in which a placeholder identifier
 /// is replaced with the numeric literal.
 struct NumericLiteralVisitor<'a> {
+    pub parameters: MacroParameters,
     pub placeholder: &'a str,
     pub float_replacement: &'a Expr,
     pub int_replacement: &'a Expr,
 }
 
 struct FloatLiteralVisitor<'a> {
+    pub parameters: MacroParameters,
     pub placeholder: &'a str,
     pub replacement: &'a Expr,
 }
 
 struct IntLiteralVisitor<'a> {
+    pub parameters: MacroParameters,
     pub placeholder: &'a str,
     pub replacement: &'a Expr,
 }
@@ -119,7 +125,7 @@ fn replace_literal(expr: &mut Expr, placeholder: &str, literal: &ExprLit) {
     replacer.visit_expr_mut(expr);
 }
 
-fn try_parse_puncuated_macro<P: ToTokens, V: VisitMut, F: Parser<Output = Punctuated<Expr, P>>>(
+fn try_parse_punctuated_macro<P: ToTokens, V: VisitMut, F: Parser<Output = Punctuated<Expr, P>>>(
     visitor: &mut V,
     mac: &mut Macro,
     parser: F,
@@ -144,13 +150,13 @@ fn visit_macros_mut<V: VisitMut>(visitor: &mut V, mac: &mut Macro) {
 
     // Handle , punctuation based macros (e.g. vec with list, assert_eq)
     let parser_comma = Punctuated::<Expr, Token![,]>::parse_separated_nonempty;
-    if try_parse_puncuated_macro(visitor, mac, parser_comma) {
+    if try_parse_punctuated_macro(visitor, mac, parser_comma) {
         return;
     }
 
     // Handle ; punctuation based macros (e.g. vec with repeat)
     let parser_semicolon = Punctuated::<Expr, Token![;]>::parse_separated_nonempty;
-    if try_parse_puncuated_macro(visitor, mac, parser_semicolon) {
+    if try_parse_punctuated_macro(visitor, mac, parser_semicolon) {
         return;
     }
 }
@@ -169,7 +175,9 @@ impl<'a> VisitMut for FloatLiteralVisitor<'a> {
     }
 
     fn visit_macro_mut(&mut self, mac: &mut Macro) {
-        visit_macros_mut(self, mac);
+        if self.parameters.visit_macros {
+            visit_macros_mut(self, mac);
+        }
     }
 }
 
@@ -187,7 +195,9 @@ impl<'a> VisitMut for IntLiteralVisitor<'a> {
     }
 
     fn visit_macro_mut(&mut self, mac: &mut Macro) {
-        visit_macros_mut(self, mac);
+        if self.parameters.visit_macros {
+            visit_macros_mut(self, mac);
+        }
     }
 }
 
@@ -200,6 +210,7 @@ impl<'a> VisitMut for NumericLiteralVisitor<'a> {
                 // parse the string
                 Lit::Int(_) => {
                     let mut visitor = IntLiteralVisitor {
+                        parameters: self.parameters,
                         placeholder: self.placeholder,
                         replacement: self.int_replacement,
                     };
@@ -208,6 +219,7 @@ impl<'a> VisitMut for NumericLiteralVisitor<'a> {
                 }
                 Lit::Float(_) => {
                     let mut visitor = FloatLiteralVisitor {
+                        parameters: self.parameters,
                         placeholder: self.placeholder,
                         replacement: self.float_replacement,
                     };
@@ -221,7 +233,9 @@ impl<'a> VisitMut for NumericLiteralVisitor<'a> {
     }
 
     fn visit_macro_mut(&mut self, mac: &mut Macro) {
-        visit_macros_mut(self, mac);
+        if self.parameters.visit_macros {
+            visit_macros_mut(self, mac);
+        }
     }
 }
 
@@ -246,18 +260,115 @@ impl<'a> VisitMut for ReplacementExpressionVisitor<'a> {
     }
 }
 
+struct MacroParameterVisitor {
+    pub name: Option<String>,
+    pub value: Option<ParameterValue>,
+}
+
+impl MacroParameterVisitor {
+    fn parse_flag(expr: &Expr) -> Option<(String, ParameterValue)> {
+        let mut visitor = MacroParameterVisitor {
+            name: None,
+            value: None,
+        };
+        visitor.visit_expr(expr);
+        let name = visitor.name.take();
+        let value = visitor.value.take();
+        name.and_then(|n| value.and_then(|v| Some((n, v))))
+    }
+}
+
+impl<'ast> Visit<'ast> for MacroParameterVisitor {
+    fn visit_expr_assign(&mut self, expr: &'ast ExprAssign) {
+        self.visit_expr(&expr.left);
+        self.visit_expr(&expr.right);
+    }
+
+    fn visit_expr_path(&mut self, expr: &'ast ExprPath) {
+        let mut name = Vec::new();
+        expr.path
+            .leading_colon
+            .map(|_| name.push(String::from("::")));
+        for p in expr.path.segments.pairs() {
+            match p {
+                syn::punctuated::Pair::Punctuated(ps, _sep) => {
+                    name.push(ps.ident.to_string());
+                    name.push(String::from("::"));
+                }
+                syn::punctuated::Pair::End(ps) => {
+                    name.push(ps.ident.to_string());
+                }
+            }
+        }
+        self.name = Some(name.concat());
+    }
+
+    fn visit_lit_bool(&mut self, expr: &'ast LitBool) {
+        self.value = Some(ParameterValue::Bool(expr.value));
+    }
+}
+
+enum ParameterValue {
+    Bool(bool),
+}
+
+#[derive(Copy, Clone)]
+struct MacroParameters {
+    pub visit_macros: bool,
+}
+
+impl Default for MacroParameters {
+    fn default() -> Self {
+        Self { visit_macros: true }
+    }
+}
+
+impl MacroParameters {
+    fn set(&mut self, name: &str, value: ParameterValue) {
+        match name {
+            "visit_macros" => match value {
+                ParameterValue::Bool(v) => self.visit_macros = v,
+            },
+            _ => {}
+        }
+    }
+}
+
+/// Obtain the replacement expression and parameters from the macro attr token stream.
+fn parse_macro_attribute(attr: TokenStream) -> Result<(Expr, MacroParameters), syn::Error> {
+    let parser = Punctuated::<Expr, Token![,]>::parse_separated_nonempty;
+    let attributes = parser.parse(attr)?;
+
+    let mut attr_iter = attributes.into_iter();
+    let replacement = attr_iter.next().expect("No replacement provided");
+
+    let user_parameters: Vec<_> = attr_iter
+        .filter_map(|expr| MacroParameterVisitor::parse_flag(&expr))
+        .collect();
+    let mut parameters = MacroParameters::default();
+    for (name, value) in user_parameters {
+        parameters.set(&name, value);
+    }
+
+    Ok((replacement, parameters))
+}
+
 /// Replace any numeric literal with custom transformation code.
 ///
 /// Refer to the documentation at the root of the crate for usage instructions.
 #[proc_macro_attribute]
 pub fn replace_numeric_literals(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(item as Item);
-    let attributes_tree = parse_macro_input!(attr as Expr);
+    let (replacement, parameters) = match parse_macro_attribute(attr) {
+        Ok(res) => res,
+        Err(err) => return TokenStream::from(err.to_compile_error()),
+    };
 
     let mut replacer = NumericLiteralVisitor {
+        parameters,
         placeholder: "literal",
-        int_replacement: &attributes_tree,
-        float_replacement: &attributes_tree,
+        int_replacement: &replacement,
+        float_replacement: &replacement,
     };
     replacer.visit_item_mut(&mut input);
 
@@ -272,11 +383,15 @@ pub fn replace_numeric_literals(attr: TokenStream, item: TokenStream) -> TokenSt
 #[proc_macro_attribute]
 pub fn replace_float_literals(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(item as Item);
-    let attributes_tree = parse_macro_input!(attr as Expr);
+    let (replacement, parameters) = match parse_macro_attribute(attr) {
+        Ok(res) => res,
+        Err(err) => return TokenStream::from(err.to_compile_error()),
+    };
 
     let mut replacer = FloatLiteralVisitor {
+        parameters,
         placeholder: "literal",
-        replacement: &attributes_tree,
+        replacement: &replacement,
     };
     replacer.visit_item_mut(&mut input);
 
@@ -291,11 +406,15 @@ pub fn replace_float_literals(attr: TokenStream, item: TokenStream) -> TokenStre
 #[proc_macro_attribute]
 pub fn replace_int_literals(attr: TokenStream, item: TokenStream) -> TokenStream {
     let mut input = parse_macro_input!(item as Item);
-    let attributes_tree = parse_macro_input!(attr as Expr);
+    let (replacement, parameters) = match parse_macro_attribute(attr) {
+        Ok(res) => res,
+        Err(err) => return TokenStream::from(err.to_compile_error()),
+    };
 
     let mut replacer = IntLiteralVisitor {
+        parameters,
         placeholder: "literal",
-        replacement: &attributes_tree,
+        replacement: &replacement,
     };
     replacer.visit_item_mut(&mut input);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -149,13 +149,13 @@ fn visit_macros_mut<V: VisitMut>(visitor: &mut V, mac: &mut Macro) {
     }
 
     // Handle , punctuation based macros (e.g. vec with list, assert_eq)
-    let parser_comma = Punctuated::<Expr, Token![,]>::parse_separated_nonempty;
+    let parser_comma = Punctuated::<Expr, Token![,]>::parse_terminated;
     if try_parse_punctuated_macro(visitor, mac, parser_comma) {
         return;
     }
 
     // Handle ; punctuation based macros (e.g. vec with repeat)
-    let parser_semicolon = Punctuated::<Expr, Token![;]>::parse_separated_nonempty;
+    let parser_semicolon = Punctuated::<Expr, Token![;]>::parse_terminated;
     if try_parse_punctuated_macro(visitor, mac, parser_semicolon) {
         return;
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -86,7 +86,7 @@ extern crate proc_macro;
 use proc_macro::TokenStream;
 
 use syn::parse::Parser;
-use syn::punctuated::{Pair, Punctuated};
+use syn::punctuated::Punctuated;
 use syn::visit::Visit;
 use syn::visit_mut::{visit_expr_mut, VisitMut};
 use syn::{
@@ -134,7 +134,7 @@ fn try_parse_punctuated_macro<P: ToTokens, V: VisitMut, F: Parser<Output = Punct
         exprs
             .iter_mut()
             .for_each(|expr| visitor.visit_expr_mut(expr));
-        mac.tts = exprs.into_token_stream();
+        mac.tokens = exprs.into_token_stream();
         return true;
     }
     return false;
@@ -144,7 +144,7 @@ fn visit_macros_mut<V: VisitMut>(visitor: &mut V, mac: &mut Macro) {
     // Handle expression based macros (e.g. assert)
     if let Ok(mut expr) = mac.parse_body::<Expr>() {
         visitor.visit_expr_mut(&mut expr);
-        mac.tts = expr.into_token_stream();
+        mac.tokens = expr.into_token_stream();
         return;
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -140,27 +140,63 @@ fn converts_vec_numeric() {
 #[test]
 fn converts_assert_eq_floats_to_i32() {
     #[replace_float_literals(literal as i32)]
-    fn assert_eq_test() -> bool {
+    fn assert_eq_test() {
         assert_eq!(1.1, 1);
         assert_eq!(2.6, 2);
         assert_eq!(10.99, 10);
-        true
     }
 
-    assert!(assert_eq_test());
+    assert_eq_test();
 }
 
 #[test]
 fn converts_assert_floats_to_i32() {
     #[replace_float_literals(literal as i32)]
-    fn assert_test() -> bool {
+    fn assert_test() {
         assert!(1.1 == 1);
         assert!(2.6 == 2);
         assert!(10.99 == 10);
-        true
     }
 
-    assert!(assert_test());
+    assert_test();
+}
+
+#[test]
+fn disable_macro_visiting() {
+    #[replace_float_literals(literal as i32, visit_macros = false)]
+    fn assert_test() {
+        assert!(1.1 != 1.0);
+        assert!(2.6 != 2.0);
+        assert!(10.99 != 10.0);
+    }
+
+    assert_test();
+
+    #[replace_numeric_literals(literal as i32,visit_macros=false )]
+    fn gen_i32_vec() -> Vec<f64> {
+        vec![3.2, 5.7, 10.1]
+    }
+
+    assert_eq!(gen_i32_vec(), vec![3.2, 5.7, 10.1]);
+}
+
+#[test]
+fn enable_macro_visiting() {
+    #[replace_float_literals(literal as i32, visit_macros = true)]
+    fn assert_test() {
+        assert!(1.1 == 1);
+        assert!(2.6 == 2);
+        assert!(10.99 == 10);
+    }
+
+    assert_test();
+
+    #[replace_numeric_literals(literal as i32,visit_macros=true )]
+    fn gen_i32_vec() -> Vec<i32> {
+        vec![3.2, 5.7, 10.1]
+    }
+
+    assert_eq!(gen_i32_vec(), vec![3, 5, 10]);
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -96,11 +96,18 @@ fn converts_floats_to_i32() {
 #[test]
 fn converts_vec_floats_to_i32() {
     #[replace_float_literals(literal as i32)]
-    fn gen_i32_vec() -> Vec<i32> {
+    fn gen_i32_vec_1() -> Vec<i32> {
         vec![3.2, 5.7, 10.1]
     }
 
-    assert_eq!(gen_i32_vec(), vec![3, 5, 10]);
+    assert_eq!(gen_i32_vec_1(), vec![3, 5, 10]);
+
+    #[replace_float_literals(literal as i32)]
+    fn gen_i32_vec_2() -> Vec<i32> {
+        vec![2.99; 4]
+    }
+
+    assert_eq!(gen_i32_vec_2(), vec![2, 2, 2, 2]);
 }
 
 #[test]
@@ -128,6 +135,32 @@ fn converts_vec_numeric() {
     }
 
     assert_eq!(gen_f64_vec(), vec![1.5, 0.5, 4.5]);
+}
+
+#[test]
+fn converts_assert_eq_floats_to_i32() {
+    #[replace_float_literals(literal as i32)]
+    fn assert_eq_test() -> bool {
+        assert_eq!(1.1, 1);
+        assert_eq!(2.6, 2);
+        assert_eq!(10.99, 10);
+        true
+    }
+
+    assert_eq_test();
+}
+
+#[test]
+fn converts_assert_floats_to_i32() {
+    #[replace_float_literals(literal as i32)]
+    fn assert_test() -> bool {
+        assert!(1.1 == 1);
+        assert!(2.6 == 2);
+        assert!(10.99 == 10);
+        true
+    }
+
+    assert_test();
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -147,7 +147,7 @@ fn converts_assert_eq_floats_to_i32() {
         true
     }
 
-    assert_eq_test();
+    assert!(assert_eq_test());
 }
 
 #[test]
@@ -160,7 +160,7 @@ fn converts_assert_floats_to_i32() {
         true
     }
 
-    assert_test();
+    assert!(assert_test());
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -94,6 +94,43 @@ fn converts_floats_to_i32() {
 }
 
 #[test]
+fn converts_vec_floats_to_i32() {
+    #[replace_float_literals(literal as i32)]
+    fn gen_i32_vec() -> Vec<i32> {
+        vec![3.2, 5.7, 10.1]
+    }
+
+    assert_eq!(gen_i32_vec(), vec![3, 5, 10]);
+}
+
+#[test]
+fn converts_vec_integers_to_f64() {
+    #[replace_int_literals(literal as f64)]
+    fn gen_f64_vec() -> Vec<f64> {
+        vec![3 / 2, 1 / 2, 9 / 2]
+    }
+
+    assert_eq!(gen_f64_vec(), vec![1.5, 0.5, 4.5]);
+}
+
+#[test]
+fn converts_vec_numeric() {
+    #[replace_numeric_literals(literal as i32)]
+    fn gen_i32_vec() -> Vec<i32> {
+        vec![3.2, 5.7, 10.1]
+    }
+
+    assert_eq!(gen_i32_vec(), vec![3, 5, 10]);
+
+    #[replace_numeric_literals(literal as f64)]
+    fn gen_f64_vec() -> Vec<f64> {
+        vec![3 / 2, 1 / 2, 9 / 2]
+    }
+
+    assert_eq!(gen_f64_vec(), vec![1.5, 0.5, 4.5]);
+}
+
+#[test]
 fn converts_generic_with_from() {
     #[replace_numeric_literals(T::from(literal))]
     fn gen<T: From<i8>>() -> T {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -138,6 +138,27 @@ fn converts_vec_numeric() {
 }
 
 #[test]
+fn converts_vec_trailing_comma() {
+    #[replace_numeric_literals(literal as i32)]
+    fn gen_i32_vec() -> Vec<i32> {
+        vec![3.2, 5.7, 10.1,]
+    }
+
+    assert_eq!(gen_i32_vec(), vec![3, 5, 10]);
+
+    #[replace_numeric_literals(literal as f64)]
+    fn gen_f64_vec() -> Vec<f64> {
+        vec![
+            3 / 2, 
+            1 / 2, 
+            9 / 2, 
+        ]
+    }
+
+    assert_eq!(gen_f64_vec(), vec![1.5, 0.5, 4.5]);
+}
+
+#[test]
 fn converts_assert_eq_floats_to_i32() {
     #[replace_float_literals(literal as i32)]
     fn assert_eq_test() {


### PR DESCRIPTION
What do you think about this for basic macros support? (issue #1) I'm not sure if this is an idiomatic solution because I just started looking into syn.

I think it might be sensible to somehow make this behavior optional, by either
- adding a flag to the proc macros to enable macro support
- adding another proc macro family that has macro support, with the current macros not supporting it
- hiding it behind a crate wide flag